### PR TITLE
Fix Dockerfile: add CentOS packages & add folder /run/lock/subsys

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,12 @@ FROM centos:centos7
 MAINTAINER Siarhei Krukau <siarhei.krukau@gmail.com>
 
 # Pre-requirements
-RUN yum install -y libaio bc; \
+RUN mkdir -p /run/lock/subsys; \
+    yum install -y libaio bc initscripts net-tools; \
     yum clean all
 
 # Install Oracle XE
-ADD rpm/oracle-xe-11.2.0-1.0.x86_64.rpm.tar.gz /tmp/
+ADD rpm/oracle-xe-11.2.0-1.0.x86_64.rpm /tmp/
 RUN yum localinstall -y /tmp/oracle-xe-11.2.0-1.0.x86_64.rpm; \
     rm -rf /tmp/oracle-xe-11.2.0-1.0.x86_64.rpm
 


### PR DESCRIPTION
When I build it, there were errors show in the console and 
these steps are throwing error messages.

I created this PR to fix those errors, 
please see my  comments (--) for solution.

Thanks,
Widi Harsojo.
https://github.com/wharsojo/myboot2docker

Step 3 : ADD rpm/oracle-xe-11.2.0-1.0.x86_64.rpm.tar.gz /tmp/
rpm/oracle-xe-11.2.0-1.0.x86_64.rpm.tar.gz: no such file or directory

-- oracle express edition distribution  already in .rpm format, 
-- update Dockerfile

Step 11 : RUN /etc/init.d/oracle-xe configure responseFile=/u01/app/oracle/product/11.2.0/xe/config/scripts/xe.rsp
 ---> Running in e6ba2830011f
/etc/init.d/oracle-xe: line 69: /etc/init.d/functions: No such file or directory

-- https://github.com/docker-library/official-images/issues/339
-- update Dockerfile: add yum install initscripts 

Do you want Oracle Database 11g Express Edition to be started on boot (y/n) [y]:
Starting Oracle Net Listener...touch: cannot touch '/var/lock/subsys/listener': No such file or directory

-- update Dockerfile: RUN mkdir -p /run/lock/subsys;

Specify the HTTP port that will be used for Oracle Application Express [8080]:
/etc/init.d/oracle-xe: line 362: netstat: command not found

-- update Dockerfile: add yum install net-tools 
